### PR TITLE
fix return value

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 func main() {
-	var balance int32 = 15_000_000_00 // 15 миллионов в копейках
-	var transfer int32 = 10_000_000_00 // 10 миллионов в копейках
+	var balance uint32 = 15_000_000_00 // 15 миллионов в копейках
+	var transfer uint32 = 10_000_000_00 // 10 миллионов в копейках
 	total := balance + transfer // int32 + int32 будет int32
 	println(total)
 }


### PR DESCRIPTION
В базовом варианте при использовании int32 получаемое значение выходит за рамки диапазона целых чисел со знаком от −128 до 127.
Решение в данном случае использование uint32 потому что в беззнаковом формате байтовое представление числа будет от 0 до 255